### PR TITLE
Size container after adding grid items

### DIFF
--- a/javascript/gridify.js
+++ b/javascript/gridify.js
@@ -28,6 +28,13 @@ Element.prototype.gridify = function (options)
             }
             return lowest;
         },
+        highestColumn = function (cols) {
+            var highest = 0;
+            for (var i = 0, length = cols.length; i < length; i++) {
+                if (cols[i] > highest) highest = cols[i];
+            }
+            return highest;
+        },
         attachEvent = function(node, event, cb)
         {
             if (node.attachEvent)
@@ -77,6 +84,7 @@ Element.prototype.gridify = function (options)
 
                 columns[idx] += items[i].clientHeight + item_margin;
             }
+            self.style.height = highestColumn(columns)+'px';
         };
     this.imagesLoaded(render);
     if (options.resizable)


### PR DESCRIPTION
I've added a function to resize the container to the height of the tallest column. Without this, the container has no height, so any footer divs get bunched up below the grid.

I only did this for the basic javascript code, not jquery or yui. Sorry about that. I don't have the time right now for a fully, tested fix.

It probably needs to be optional.
